### PR TITLE
Feature/built in functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for Pref
 
+## 0.6.0.0 -- 2021-09-06
+
+* Allow built-in functions to be used like normal functions
+* Make `let` behave like Racket's `let` (i.e., binding `n`
+  doesn't have binding `n-1` in scope)
+* Remove n-ary operators (allows currying built-in operators)
+
 ## 0.5.0.0 -- 2020-06-10
 
 * Make Pref call-by-need (Lazy)

--- a/README.md
+++ b/README.md
@@ -3,16 +3,29 @@
 
 (A simple project to get comfortable with my current Haskell dev environment, cabal etc.)
 
+**Pref** is a lazy, lisp-like programming language
+
 ---
 
-## Features
+## Usage
 
-**Pref** is a lazy, lisp-like programming language with the following features:
+### Installing Haskell & Cabal
 
-* Higher Order Functions
-* S-Expressions
-* Local Variable Bindings
-* Top Level Recursive Functions
+To use Pref, you need to have a minimal Haskell dev-environment installed.
+
+On \*nix systems, checkout [ghcup](https://www.haskell.org/ghcup/) to install both Haskell and Cabal
+
+### Interpreting Pref programs
+
+With `cabal-install` installed, you can execute the following commands to evaluate a Pref program:
+
+```
+> cabal build all
+> cabal exec pref *path*
+```
+
+where *path* points to a file containing a Pref program
+(also take a look at the .github CI/CD setup for running tests)
 
 ---
 
@@ -24,13 +37,13 @@
      | (lambda (x ...) e)  
      | (let ([x e] ...) e)  
      | (if e e e)  
-     | (b e ...)  
      | *empty*  
      | c
+     | B
 * x ::= *variable*
-* B ::= + | - | * | \ | cons | car | cdr | empty? | zero? | string-append | fix
 * c ::= integer | string | b
 * b ::= #t | #f
+* B ::= + | - | * | / | cons | car | cdr | empty? | zero? | string-append | fix | and | or | not
 
 You can also use braces or brackets instead of parenthesis where needed.
 
@@ -59,7 +72,7 @@ Pref comes with the following built-in data types:
 
 ## `define`
 
-The `define` grammar can be used to define top-level contants and functions.
+The `define` grammar can be used to define top-level constants and functions.
 
 For top-level functions, `define` is used as follows:
 
@@ -69,36 +82,10 @@ Currently, `define` can only be used at the top level.
 
 ---
 
-## Usage
-
-### Installing Haskell & Cabal
-
-To use Pref, you need to have a minimal Haskell dev-environment installed.
-
-On \*nix systems, checkout [ghcup](https://www.haskell.org/ghcup/) to install both Haskell and Cabal
-
-### Interpreting Pref programs
-
-With `cabal-install` installed, you can execute the following commands to evaluate a Pref program:
-
-```
-> cabal build all
-> cabal exec pref *path*
-```
-
-where *path* points to a file containing a Pref program
-
----
-
 ## TODOs
 
-* Higher Order Operators: Improve the interpreter so operators like `+`, `fix` etc can be treated like data.
-* Lazy Evaluation.
 * Allow user to choose an evaluation strategy by passing in certain flags.
 * Data Types: Allow user to define their own data type and (maybe) using pattern matching to work with the data.
-* Tag interesting points: For people interested, different versions of Pref will be tagged to see different approaches  
-                          taken during this project. For example, viewers can check Pref when it didn't use Parsec, or  
-                          when it wasn't lazy.
 * Refactor: Pref had a rough start which is why `define` can only be used at the top-level. This should be allowed where  
             a user expects to use `let`. 
 * Error Locations: Both parser and the interpreter should indicate the location where the error occured.

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -40,7 +40,10 @@ expParser =
 
  where
   idParser :: Parsec T.Text () Exp
-  idParser = identifier >>= (return . Id)
+  idParser = do
+    ident <- identifier
+    let val = if ident == "empty" then Syntax.Exp.Empty else (Id ident) 
+    return val
 
   boolParser :: Parsec T.Text () Exp
   boolParser = bool >>= (return . BLiteral)

--- a/tests/InterpTests.hs
+++ b/tests/InterpTests.hs
@@ -31,17 +31,21 @@ allTests =
                 [e]
                 (either (\_ -> []) (fromRight []) $ codeToVal test)
   | (test, e) <-
-    [ ("1"                          , I 1)
-    , ("\"a\""                      , S "a")
-    , ("(lambda (x) 2)"             , C "x" (NLiteral 2) defaultEnv)
-    , ("((lambda (x) 2) 3)"         , I 2)
-    , ("((lambda (x) x) 3)"         , I 3)
-    , ("((lambda (x y z) z) 3 4 5)" , I 5)
-    , ("(let ((x 1) (y 2) (z 3)) z)", I 3)
-    , ("((lambda () 2))"            , I 2)
+    [ ("1"    , I 1)
+    , ("\"a\"", S "a")
+    , ( "(lambda (x) 2)"
+      , C "x" (PrefE $ NLiteral 2) (fst prepareDefaultBindings)
+      )
+    , ("((lambda (x) 2) 3)"                 , I 2)
+    , ("((lambda (x) x) 3)"                 , I 3)
+    , ("((lambda (x y z) z) 3 4 5)"         , I 5)
+    , ("(let ((x 1) (y 2) (z 3)) z)"        , I 3)
+    , ("((lambda () 2))"                    , I 2)
     , ("(string-append \"Hello\" \"World\")", S "HelloWorld")
-    , ("(string-append \"Hello\" \" \" \"World\")", S "Hello World")
-    , ("(define five 5) five"       , I 5)
+    , ( "(string-append \"Hello\" (string-append \" \" \"World\"))"
+      , S "Hello World"
+      )
+    , ("(define five 5) five", I 5)
     , ("(fix (lambda (fact x) (if (zero? x) 1 (* x (fact (- x 1))))) 5)", I 120)
     , ( "(fix (lambda (fib last curr n)\
                           \ (if (zero? (- n 2)) curr (fib curr (+ last curr) (- n 1)))) 1 1 6)"

--- a/tests/test-files/test2.pref
+++ b/tests/test-files/test2.pref
@@ -1,6 +1,6 @@
 (define fact
   (lambda (f x) 
-   (if (zero? x) 1 (* x ((f f) (- x 1))))))
+   (if (zero? x) 1 (* x (f f (- x 1))))))
 
 (fact fact 5)
 

--- a/tests/test-files/test4.pref
+++ b/tests/test-files/test4.pref
@@ -16,6 +16,6 @@
   (fix (lambda (powerset ls)
          (if (empty? ls) (cons empty empty)
              (append (powerset (cdr ls))
-                     (map (lambda (x) (cons (car ls) x)) (powerset (cdr ls))))))))
+                     (map (cons (car ls)) (powerset (cdr ls))))))))
 
 (powerset (cons 1 (cons 2 (cons 3 empty))))


### PR DESCRIPTION
* interpreter cleanup
* allow higher order operators to be used like functions
* make `let` behave like `Racket`s `let`
* make types more "readable" (I try)
* parse `empty` instead of creating it a default value